### PR TITLE
Support for BSN validating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "ronanguilloux/isocodes": "^2.1"
+    "ronanguilloux/isocodes": "dev-master"
   },
   "autoload": {
     "psr-4": {

--- a/lang/de/validation.php
+++ b/lang/de/validation.php
@@ -2,6 +2,7 @@
 
 return [
     'bban'                      => 'Der Wert ":value" von :attribute ist kein gültiger BBAN Code.',
+    'bsn'                       => 'Der Wert ":value" von :attribute ist kein gültiger BSN.',
     'cif'                       => 'Der Wert ":value" von :attribute ist kein gültiger CIF Code.',
     'creditcard'                => 'Der Wert ":value" von :attribute ist keine gültige Kreditkartennummer.',
     'ean8'                      => 'Der Wert ":value" von :attribute ist kein gültiger EAN8 Code.',

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -2,6 +2,7 @@
 
 return [
     'bban'                      => 'The value ":value" of :attribute is not a valid BBAN code.',
+    'bsn'                       => 'The value ":value" of :attribute is not a valid BSN.',
     'cif'                       => 'The value ":value" of :attribute is not a valid CIF code.',
     'creditcard'                => 'The value ":value" of :attribute is not a valid credit card number.',
     'ean8'                      => 'The value ":value" of :attribute is not a valid EAN8 code.',

--- a/src/IsoCodesValidator.php
+++ b/src/IsoCodesValidator.php
@@ -23,6 +23,19 @@ class IsoCodesValidator extends BaseValidator
     }
 
     /**
+     * Validate a BSN (Dutch citizen service number)
+     *
+     * @param $attribute
+     * @param $value
+     * @param $parameters
+     * @return mixed
+     */
+    public function validateBsn($attribute, $value, $parameters)
+    {
+        return $this->runIsoCodesValidator(\IsoCodes\Bsn::class, $value);
+    }
+
+    /**
      * Validate a CIF code
      *
      * @param $attribute
@@ -447,6 +460,20 @@ class IsoCodesValidator extends BaseValidator
      * @return mixed
      */
     public function replaceBban($message, $attribute, $rule, $parameter)
+    {
+        return $this->valueReplacer($message, $attribute);
+    }
+
+    /**
+     * Replace all place-holders for the bsn rule
+     *
+     * @param $message
+     * @param $attribute
+     * @param $rule
+     * @param $parameter
+     * @return mixed
+     */
+    public function replaceBsn($message, $attribute, $rule, $parameter)
     {
         return $this->valueReplacer($message, $attribute);
     }


### PR DESCRIPTION
I added support for BSN since it's supported by the dev-master of IsoCodes. I needed to update the 2.1 version in de Composer file to dev-master, so I'm not sure if you want to merge it. But please let me know. We're enjoying laravel5-isocodes-validation, thanks! 👍 

PS. I didn't had time to add tests, I'm sorry.
